### PR TITLE
feat : 게시글 삭제 API 추가

### DIFF
--- a/src/main/java/com/example/laweasy/config/BaseResponseStatus.java
+++ b/src/main/java/com/example/laweasy/config/BaseResponseStatus.java
@@ -47,7 +47,8 @@ public enum BaseResponseStatus {
     FAILED_TO_LOGIN(false,3014,"없는 아이디거나 비밀번호가 틀렸습니다."),
     FAILED_TO_FIND_USER(false, 3015, "존재하지 않는 회원입니다. 회원가입이 필요합니다."),
 
-
+    // [PATCH] /posts
+    DELETE_FAIL_POST(false, 3016, "이미 삭제된 게시글입니다."),
 
     /**
      * 4000 : Database, Server 오류

--- a/src/main/java/com/example/laweasy/controller/PostController.java
+++ b/src/main/java/com/example/laweasy/controller/PostController.java
@@ -1,6 +1,8 @@
 package com.example.laweasy.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,7 +24,7 @@ public class PostController {
 	private final PostService postService;
 
 	/**
-	 * 게시물 작성
+	 * 게시글 작성
 	 *
 	 * @param postPostReqDto
 	 * @return
@@ -37,8 +39,13 @@ public class PostController {
 		}
 	}
 
-	@PatchMapping
-	public BaseResponse<String> deletePost(@RequestParam Long postId) {
+	/**
+	 * 게시글 삭제
+	 * @param postId
+	 * @return
+	 */
+	@PatchMapping("/{postId}")
+	public BaseResponse<String> deletePost(@PathVariable Long postId) {
 		try {
 			postService.deletePost(postId);
 			String result = "게시글 삭제 성공";
@@ -47,4 +54,5 @@ public class PostController {
 			return new BaseResponse<>(exception.getStatus());
 		}
 	}
+
 }

--- a/src/main/java/com/example/laweasy/controller/PostController.java
+++ b/src/main/java/com/example/laweasy/controller/PostController.java
@@ -1,8 +1,10 @@
 package com.example.laweasy.controller;
 
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.laweasy.config.BaseException;
@@ -21,12 +23,28 @@ public class PostController {
 
 	/**
 	 * 게시물 작성
+	 *
 	 * @param postPostReqDto
 	 * @return
 	 */
 	@PostMapping
-	public BaseResponse<PostPostResDto> createPost(@RequestBody PostPostReqDto postPostReqDto) throws BaseException {
-		PostPostResDto postPostResDto = postService.createPost(postPostReqDto);
-		return new BaseResponse<>(postPostResDto);
+	public BaseResponse<PostPostResDto> createPost(@RequestBody PostPostReqDto postPostReqDto) {
+		try {
+			PostPostResDto postPostResDto = postService.createPost(postPostReqDto);
+			return new BaseResponse<>(postPostResDto);
+		} catch (BaseException exception) {
+			return new BaseResponse<>(exception.getStatus());
+		}
+	}
+
+	@PatchMapping
+	public BaseResponse<String> deletePost(@RequestParam Long postId) {
+		try {
+			postService.deletePost(postId);
+			String result = "게시글 삭제 성공";
+			return new BaseResponse<>(result);
+		} catch (BaseException exception) {
+			return new BaseResponse<>(exception.getStatus());
+		}
 	}
 }

--- a/src/main/java/com/example/laweasy/domain/Post.java
+++ b/src/main/java/com/example/laweasy/domain/Post.java
@@ -11,16 +11,17 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
-import org.hibernate.annotations.Fetch;
-
 import com.example.laweasy.domain.core.BaseTimeEntity;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "post")
@@ -36,6 +37,9 @@ public class Post extends BaseTimeEntity {
 	@Column(name = "content", nullable = false)
 	private String content;
 
+	@Column(name = "activated", nullable = false)
+	private boolean activated;
+
 	@Column(name = "resolve_status", nullable = false)
 	private boolean resolveStatus;
 
@@ -47,12 +51,7 @@ public class Post extends BaseTimeEntity {
 	@JoinColumn(name = "member_id")
 	private Member member;
 
-	@Builder
-	public Post(String title, String content, boolean resolveStatus, Category category, Member member) {
-		this.title = title;
-		this.content = content;
-		this.resolveStatus = resolveStatus;
-		this.category = category;
-		this.member = member;
+	public void updateActivated(boolean activated) {
+		this.activated = activated;
 	}
 }

--- a/src/main/java/com/example/laweasy/service/PostService.java
+++ b/src/main/java/com/example/laweasy/service/PostService.java
@@ -7,6 +7,7 @@ import javax.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import com.example.laweasy.config.BaseException;
+import com.example.laweasy.config.BaseResponseStatus;
 import com.example.laweasy.domain.Member;
 import com.example.laweasy.domain.Post;
 import com.example.laweasy.dto.PostPostReqDto;
@@ -33,6 +34,7 @@ public class PostService {
 			Post newPost = Post.builder()
 				.title(postPostReqDto.getTitle())
 				.content(postPostReqDto.getContent())
+				.activated(true)
 				.resolveStatus(false)
 				.category(postPostReqDto.getCategory())
 				.member(member)
@@ -47,5 +49,24 @@ public class PostService {
 
 	public String createGptComment(String content) {
 		return "gpt 댓글 : " + content;
+	}
+
+	@Transactional
+	public void deletePost(Long postId) throws BaseException {
+		Long memberId = jwtService.getMemberId();
+		Post post;
+
+		try {
+			post = postRepository.getReferenceById(postId);
+			if (post.getMember().getId() != memberId) {
+				throw new BaseException(BaseResponseStatus.INVALID_USER_JWT);
+			}
+			if (!post.isActivated()) {
+				throw new BaseException(BaseResponseStatus.DELETE_FAIL_POST);
+			}
+			post.updateActivated(false);
+		} catch (BaseException e) {
+			throw new BaseException(e.getStatus());
+		}
 	}
 }

--- a/src/main/java/com/example/laweasy/service/PostService.java
+++ b/src/main/java/com/example/laweasy/service/PostService.java
@@ -53,11 +53,9 @@ public class PostService {
 
 	@Transactional
 	public void deletePost(Long postId) throws BaseException {
-		Long memberId = jwtService.getMemberId();
-		Post post;
-
 		try {
-			post = postRepository.getReferenceById(postId);
+			Long memberId = jwtService.getMemberId();
+			Post post = postRepository.getReferenceById(postId);
 			if (post.getMember().getId() != memberId) {
 				throw new BaseException(BaseResponseStatus.INVALID_USER_JWT);
 			}


### PR DESCRIPTION
## 1. 요약
- Post 엔티티에 activated 필드 추가
- PostController에 게시글 삭제 API 추가
- PostService에 게시물 삭제하는 deletePost 메소드 추가

## 2. 코드
### 1. Post.java
```java
        @Column(name = "activated", nullable = false)
	private boolean activated;
        ....
        public void updateActivated(boolean activated) {
		this.activated = activated;
	}
```
- 삭제 여부를 저장하는 activated 필드 추가 (삭제된 게시글인 경우 false)
- activated 필드 값을 update하는 updateActivated 메소드 추가 

### 2. PostService.java
```java
@Transactional
	public void deletePost(Long postId) throws BaseException {
		try {
			Long memberId = jwtService.getMemberId();
			Post post = postRepository.getReferenceById(postId);
			if (post.getMember().getId() != memberId) {
				throw new BaseException(BaseResponseStatus.INVALID_USER_JWT);
			}
			if (!post.isActivated()) {
				throw new BaseException(BaseResponseStatus.DELETE_FAIL_POST);
			}
			post.updateActivated(false);
		} catch (BaseException e) {
			throw new BaseException(e.getStatus());
		}
	}
}
```
- 게시글을 쓴 유저와 로그인한 유저가 일치하지 않은 경우 예외 처리
- 게시글이 이미 삭제된 경우 예외 처리

### 3. PostController.java
``` java
@PatchMapping
	public BaseResponse<String> deletePost(@RequestParam Long postId) {
		try {
			postService.deletePost(postId);
			String result = "게시글 삭제 성공";
			return new BaseResponse<>(result);
		} catch (BaseException exception) {
			return new BaseResponse<>(exception.getStatus());
		}
	}
```